### PR TITLE
feat/nvme-discovery: create nvme device link based on label provided on the aws volume

### DIFF
--- a/files/999-aws-ebs-nvme.rules
+++ b/files/999-aws-ebs-nvme.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="block", KERNEL=="nvme[0-26]n1", ATTRS{model}=="Amazon Elastic Block Store              ", RUN+="/usr/local/bin/ebs-nvme-mapping"

--- a/files/ebs-nvme-mapping
+++ b/files/ebs-nvme-mapping
@@ -3,6 +3,9 @@
 PATH="${PATH}:/usr/sbin"
 
 for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
-  mapping="/dev/$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')"
-  ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -fs "${blkdev}" "${mapping}"
+  mapping="/dev/$(nvme id-ctrl --raw-binary "${blkdev}" 2> /dev/null| cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')"
+  if [[ "$mapping" == "/dev/" ]]; then
+	  continue
+  fi
+  ( test -b "${blkdev}" && test -L "${mapping}" ) || echo ln -fs "${blkdev}" "${mapping}"
 done

--- a/files/ebs-nvme-mapping
+++ b/files/ebs-nvme-mapping
@@ -6,4 +6,3 @@ for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
   mapping="/dev/$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')"
   ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -fs "${blkdev}" "${mapping}"
 done
-

--- a/files/ebs-nvme-mapping
+++ b/files/ebs-nvme-mapping
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PATH="${PATH}:/usr/sbin"
+
+for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
+  mapping="/dev/$(nvme id-ctrl --raw-binary "${blkdev}" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')"
+  ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -fs "${blkdev}" "${mapping}"
+done
+

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,0 +1,29 @@
+---
+- name: nvme | ensure nvme-cli is present
+  package:
+    state: present
+    name: "nvme-cli"
+
+- name: nvme | ensure /usr/local/bin directory
+  file:
+    path: /usr/local/bin
+    state: directory
+
+- name: nvme | copy mapping script
+  copy:
+    src: ebs-nvme-mapping
+    dest: /usr/local/bin/ebs-nvme-mapping
+    owner: root
+    group: root
+    mode: 0755
+
+- name: nvme | copy udev script
+  copy:
+    src: 999-aws-ebs-nvme.rules
+    dest: /etc/udev/rules.d/999-aws-ebs-nvme.rules
+    owner: root
+    group: root
+    mode: 0644
+
+- name: nvme | run mapping script
+  command: /usr/local/bin/ebs-nvme-mapping

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -27,3 +27,5 @@
 
 - name: nvme | run mapping script
   command: /usr/local/bin/ebs-nvme-mapping
+  args:
+    creates: /var/opt/.ebs-nvme-mapping

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -28,4 +28,4 @@
 - name: nvme | run mapping script
   command: /usr/local/bin/ebs-nvme-mapping
   args:
-    creates: /var/opt/.ebs-nvme-mapping
+    creates: /var/opt/ebs-nvme-mapping

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: dependencies.yml
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version > '14'
 
 - name: Looking for Data disk
   stat: path="{{ item.disk }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: dependencies.yml
+
 - name: Looking for Data disk
   stat: path="{{ item.disk }}"
   register: ret_stat_disk


### PR DESCRIPTION
The nvme volumes does not keep the same ids on reboot, sometimes the root disk is nvme0n1 and after a reboot it becomes nvme1n1.

This PR implements a script that creates the /dev/sd* pointing to the nvme device based on the label specified at the volume creation. It has no impact on instances not running on nvme disks.