### PR TITLE
fix/nvme: run nvme link creation on all systems except ubuntu <= 14

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: dependencies.yml
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version > '14'
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version <= '14')
 
 - name: Looking for Data disk
   stat: path="{{ item.disk }}"


### PR DESCRIPTION
it was running only on instances that have Ubuntu > 14, now it will run on all distros (not only Ubuntu)