### PR TITLE
feat/install-xfs: install xfsprogs if any disk is configured to use xfs

### DIFF
--- a/tasks/fs.yml
+++ b/tasks/fs.yml
@@ -1,4 +1,12 @@
 ---
+- name: Installing xfs
+  package:
+    name: xfsprogs
+    state: latest
+  with_items: "{{ disk_devices }}"
+  when: item.fs_type == "xfs"
+  ignore_errors: yes
+
 - name: Creating filesystem in partition
   filesystem:
     dev: "{{ item.device }}"


### PR DESCRIPTION
`ignore_errors: yes` is enabled because I didn't test on all distros, I tested on Debian, Ubuntu and CentOS 7 (Amazon Linux should work fine)