### PR TITLE
feat/by-id: add option to specify disk by id

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include: manual_link.yml
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version <= '14'
+
 - include: dependencies.yml
   when: not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version <= '14')
 

--- a/tasks/manual_link.yml
+++ b/tasks/manual_link.yml
@@ -1,0 +1,12 @@
+---
+
+# On old releases nvme-cli is not available so using a new field
+# called id to get the first ephemeral disk based on disk id.
+# The problem is that the disk id have a random number in the end
+# so using shell to solve this for us.
+- shell:
+    cmd: "ln -sf {{item.id}} {{item.disk}}"
+    warn: false
+  when: item.id is defined
+  with_items:
+    - "{{ disk_devices }}"


### PR DESCRIPTION
On old releases nvme-cli is not available so using a new field
called id to get the first ephemeral disk based on disk id.
The problem is that the disk id have a random number in the end
so using shell to solve this for us.
