### PR TITLE
fix: Add some code to remove prefix from 'nvme id-ctrl' command when retrieving ebs info

### DIFF
--- a/files/ebs-nvme-mapping
+++ b/files/ebs-nvme-mapping
@@ -7,7 +7,7 @@ for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
   if [[ "$mapping" == "/dev/" ]]; then
 	  continue
   fi
-  dev_prefix="/dev"
+  dev_prefix="/dev/"
   mapping=${mapping/#$dev_prefix} #remove /dev/ prefix if present
   ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -fs "${blkdev}" "${mapping}"
 done

--- a/files/ebs-nvme-mapping
+++ b/files/ebs-nvme-mapping
@@ -7,5 +7,7 @@ for blkdev in $( nvme list | awk '/^\/dev/ { print $1 }' ) ; do
   if [[ "$mapping" == "/dev/" ]]; then
 	  continue
   fi
+  dev_prefix="/dev"
+  mapping=${mapping/#$dev_prefix} #remove /dev/ prefix if present
   ( test -b "${blkdev}" && test -L "${mapping}" ) || ln -fs "${blkdev}" "${mapping}"
 done


### PR DESCRIPTION
When attaching a disk using terraform the disk path (using nvme id-ctrl) is been returned with '/dev/' prefix

![image](https://user-images.githubusercontent.com/4291249/92265686-bfa56400-eeb5-11ea-88b9-f23543b5cc4b.png)

So I did a little fix to remove this prefix if it exists